### PR TITLE
more accurate id type matchers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,33 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: salsify/ruby_ci:2.5.1
+    working_directory: ~/gtin
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v1-gems-ruby-2.5.1-{{ checksum "salsify-jira.gemspec" }}-{{ checksum "Gemfile.lock" }}
+            - v1-gems-ruby-2.5.1-
+      - run:
+          name: Install Gems
+          command: |
+            if ! bundle check --path=vendor/bundle; then
+              bundle install --path=vendor/bundle --jobs=4 --retry=3
+              bundle clean
+            fi
+      - save_cache:
+          key: v1-gems-ruby-2.5.1-{{ checksum "salsify-jira.gemspec" }}-{{ checksum "Gemfile.lock" }}
+          paths:
+            - "vendor/bundle"
+            - "gemfiles/vendor"
+      - run:
+          name: Run Rubocop
+          command: bundle exec rubocop
+      - run:
+          name: Run Tests
+          command: |
+            bundle exec rspec --format RspecJunitFormatter --out $CIRCLE_TEST_REPORTS/rspec/junit.xml --format progress spec
+      - store_test_results:
+          path: 'test-results'

--- a/lib/gtin/gtin.rb
+++ b/lib/gtin/gtin.rb
@@ -9,17 +9,15 @@ module GTIN
   IssnConverter = Converter.new(:standardize_issn8, :compute_checksum_issn8)
 
   CONVERTER_MAP = {
-    [/(GTIN|EAN)(-8)?/i, 8] => GtinConverter,
-    [/(GTIN|EAN)(-12)?/i, 12] => GtinConverter,
-    [/(GTIN|EAN|ISBN|ISSN)(-13)?/i, 13] => GtinConverter,
-    [/(GTIN|EAN)(-14)?/i, 14] => GtinConverter,
-    [/UPC(-A)?/i, 12] => GtinConverter,
-    [/UPC(-E)?/i, 7] => UpcEConverter,
-    [/ISBN(-10)?/i, 10] => IsbnConverter,
-    [/ISSN(-8)?/i, 8] => IssnConverter
+    [/^(GTIN|EAN)(-?8)?$/i, 8] => GtinConverter,
+    [/^(GTIN|EAN)(-?12)?$/i, 12] => GtinConverter,
+    [/^(GTIN|EAN|ISBN|ISSN)(-?13)?$/i, 13] => GtinConverter,
+    [/^(GTIN|EAN)(-?14)?$/i, 14] => GtinConverter,
+    [/^UPC(-?A)?$/i, 12] => GtinConverter,
+    [/^UPC(-?E)?$/i, 7] => UpcEConverter,
+    [/^ISBN(-?10)?$/i, 10] => IsbnConverter,
+    [/^ISSN(-?8)?$/i, 8] => IssnConverter
   }.freeze
-
-  GTIN_COMPATIBLE_ID_TYPES = %w(UPC GTIN EAN ISSN ISBN).freeze
 
   GtinValidationError = Class.new(StandardError)
 
@@ -112,5 +110,9 @@ module GTIN
   # can't be done directly; convert to upc-a first
   def compute_checksum_upce(unchecked_upce)
     standardize('UPC', unchecked_upce + '0', validate_checksum: false)[-1]
+  end
+
+  def gtin_compatible?(id_type)
+    CONVERTER_MAP.keys.map(&:first).any? { |r| r.match?(id_type) }
   end
 end

--- a/lib/gtin/version.rb
+++ b/lib/gtin/version.rb
@@ -1,3 +1,3 @@
 module GTIN
-  VERSION = '0.1.0'.freeze
+  VERSION = '0.2.0'.freeze
 end

--- a/spec/gtin_spec.rb
+++ b/spec/gtin_spec.rb
@@ -3,6 +3,23 @@ describe GTIN do
     expect(GTIN::VERSION).not_to be nil
   end
 
+  describe "#gtin_compatible?" do
+    positives = ['GTIN', 'GTIN-14', 'GTIN14', 'ISBN', 'UPC-E', 'UPCE']
+    negatives = ['UTF', 'NOTUPC', 'GTIN41']
+
+    positives.each do |id_type|
+      it "#{id_type} is GTIN-copmatible" do
+        expect(GTIN.gtin_compatible?(id_type)).to eq(true)
+      end
+    end
+
+    negatives.each do |id_type|
+      it "#{id_type} is not GTIN-copmatible" do
+        expect(GTIN.gtin_compatible?(id_type)).to eq(false)
+      end
+    end
+  end
+
   context "direct conversions" do
     direct_test_cases = [
       ['ISSN', '20493630', '09772049363002'],


### PR DESCRIPTION
Added `^` and `$` markers and made hyphen-before-length optional to match what I found in the wild.