### PR TITLE
Upgrade CircleCI config to version 2.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.1
 jobs:
   build:
     docker:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Changed
+- Upgrade CircleCI config to version 2.1. CircleCI ends support for version 2.0 config compilation on 2026-08-17 ([announcement](https://discuss.circleci.com/t/breaking-changes-config-compilation-updates-august-17-2026/54719)).
 
 ## 0.1.0 - 2019-01-30
 ### Added


### PR DESCRIPTION
Prepares the CircleCI config for the August 17, 2026 end of support for `version: 2.0` config compilation. See: https://discuss.circleci.com/t/breaking-changes-config-compilation-updates-august-17-2026/54719

Changes:
- Bump config to `version: 2.1`.

Validated against the upcoming compiler with `circleci config validate --next` — passes. No other changes were required: the root `version` key is already at the top of the file and there is no `workflows:` block, so nothing else needed adjusting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)